### PR TITLE
use ReactPlayer and iFrame APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react-player": "^2.12.0"
+  }
+}

--- a/site/gatsby-site/src/components/cite/VideoPlayerCard.js
+++ b/site/gatsby-site/src/components/cite/VideoPlayerCard.js
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import VideoPlayer from 'components/cite/VideoPlayer';
+import Row from '../../elements/Row';
+import Col from '../../elements/Col';
+import Card from '../../elements/Card';
+import { Trans } from 'react-i18next';
+
+const VideoPlayerCard = ({ videoURLs = [], index = 0, fallback = null }) => {
+  if (index >= videoURLs.length) return fallback;
+  const [works, setWorks] = useState(true);
+
+  return works ? (
+    <Row>
+      <Col>
+        <Card className="border-1.5 border-border-light-gray rounded-5px shadow-card mt-6">
+          <Card.Header className="items-center justify-between">
+            <h4 className="m-0">
+              <Trans ns="video">Incident Video</Trans>
+            </h4>
+          </Card.Header>
+          <Card.Body className="block">
+            <VideoPlayer
+              mediaURL={videoURLs[index]}
+              onError={() => {
+                console.log(`VPC: ${videoURLs[index]} didn't work`);
+                setWorks(false);
+              }}
+            />
+          </Card.Body>
+        </Card>
+      </Col>
+    </Row>
+  ) : (
+    <VideoPlayerCard videoURLs={videoURLs} index={index + 1} fallback={fallback} />
+  );
+};
+
+export default VideoPlayerCard;

--- a/site/gatsby-site/src/components/discover/hitTypes/Details.js
+++ b/site/gatsby-site/src/components/discover/hitTypes/Details.js
@@ -15,7 +15,7 @@ import TranslationBadge from 'components/i18n/TranslationBadge';
 import Card from 'elements/Card';
 import { VIEW_TYPES } from 'utils/discover';
 
-import VideoPlayer, { isVideo } from 'components/cite/VideoPlayer';
+import VideoPlayer from 'components/cite/VideoPlayer';
 
 const IncidentCardImage = styled(Image)`
   height: ${({ height }) => height};
@@ -58,25 +58,22 @@ export default function Details({
       <input type="hidden" data-cy="date-submitted" value={item.epoch_date_submitted} />
       <input type="hidden" data-cy="incident-date" value={item.epoch_incident_date} />
       <a href={detailsPath}>
-        {isVideo(item.media_url) ? (
-          <VideoPlayer
-            //   className={`img-fluid h-full w-full max-w-full object-cover`}
-            className="card-img-top"
-            incidentID={item.incident_id}
-            mediaURL={item.media_url}
-          />
-        ) : (
-          <IncidentCardImage
-            className="card-img-top"
-            publicID={item.cloudinary_id ? item.cloudinary_id : `legacy/${md5(item.media_url)}`}
-            alt={item.title}
-            height="240px"
-            transformation={fill().height(480)}
-            itemIdentifier={t('Report {{report_number}}', {
-              report_number: item.report_number,
-            }).replace(' ', '.')}
-          />
-        )}
+        <VideoPlayer
+          className="card-img-top"
+          mediaURL={item.media_url}
+          fallback={
+            <IncidentCardImage
+              className="card-img-top"
+              publicID={item.cloudinary_id ? item.cloudinary_id : `legacy/${md5(item.media_url)}`}
+              alt={item.title}
+              height="240px"
+              transformation={fill().height(480)}
+              itemIdentifier={t('Report {{report_number}}', {
+                report_number: item.report_number,
+              }).replace(' ', '.')}
+            />
+          }
+        />
       </a>
       <Card.Body className="flex flex-col ">
         <HeaderTitle item={item} viewType={viewType} />

--- a/site/gatsby-site/src/components/reports/ReportCard.js
+++ b/site/gatsby-site/src/components/reports/ReportCard.js
@@ -15,7 +15,7 @@ import { RESPONSE_TAG } from 'utils/entities';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import { hasVariantData } from 'utils/variants';
-import VideoPlayer, { isVideo } from 'components/cite/VideoPlayer';
+import VideoPlayer from 'components/cite/VideoPlayer';
 
 const ReportCard = ({ item, className = '', incidentId }) => {
   const { isRole, loading } = useUserContext();
@@ -61,23 +61,21 @@ const ReportCard = ({ item, className = '', incidentId }) => {
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >
-          {isVideo(item.media_url) ? (
-            <VideoPlayer
-              className={`img-fluid h-full w-full max-w-full object-cover`}
-              incidentID={incidentId}
-              mediaURL={item.media_url}
-            />
-          ) : (
-            <Image
-              className={`img-fluid h-full w-full max-w-full object-cover`}
-              publicID={item.cloudinary_id ? item.cloudinary_id : `legacy/${md5(item.media_url)}`}
-              alt={item.title}
-              transformation={fill().height(480)}
-              itemIdentifier={t('Report {{report_number}}', {
-                report_number: item.report_number,
-              }).replace(' ', '.')}
-            />
-          )}
+          <VideoPlayer
+            className={`img-fluid h-full w-full max-w-full object-cover`}
+            mediaURL={item.media_url}
+            fallback={
+              <Image
+                className={`img-fluid h-full w-full max-w-full object-cover`}
+                publicID={item.cloudinary_id ? item.cloudinary_id : `legacy/${md5(item.media_url)}`}
+                alt={item.title}
+                transformation={fill().height(480)}
+                itemIdentifier={t('Report {{report_number}}', {
+                  report_number: item.report_number,
+                }).replace(' ', '.')}
+              />
+            }
+          />
         </div>
         <div
           className="mt-0 cursor-default"

--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -38,7 +38,8 @@ import config from '../../config';
 import VariantList from 'components/variants/VariantList';
 import { isCompleteReport } from 'utils/variants';
 import { useQueryParams, StringParam, withDefault } from 'use-query-params';
-import VideoPlayer, { isVideo } from 'components/cite/VideoPlayer';
+import { isVideo } from 'components/cite/VideoPlayer';
+import VideoPlayerCard from 'components/cite/VideoPlayerCard';
 
 const sortIncidentsByDatePublished = (incidentReports) => {
   return incidentReports.sort((a, b) => {
@@ -114,11 +115,17 @@ function CitePage(props) {
 
   const sortedIncidentReports = sortIncidentsByDatePublished(incidentReports);
 
-  const sortedReports = sortedIncidentReports.filter((report) => isCompleteReport(report));
+  const sortedReports = sortedIncidentReports
+    .filter((report) => isCompleteReport(report))
+    .reverse();
 
   const publicID = sortedReports.find((report) => report.cloudinary_id)?.cloudinary_id;
 
-  const videoURL = sortedReports.find((report) => isVideo(report.media_url))?.media_url;
+  let videoURLs = [];
+
+  sortedReports.forEach((report) => {
+    if (isVideo(report.media_url)) videoURLs.push(report.media_url);
+  });
 
   const image = new CloudinaryImage(publicID, {
     cloudName: config.cloudinary.cloudName,
@@ -282,22 +289,7 @@ function CitePage(props) {
           </div>
 
           <Container>
-            {videoURL && (
-              <Row>
-                <Col>
-                  <Card className="border-1.5 border-border-light-gray rounded-5px shadow-card mt-6">
-                    <Card.Header className="items-center justify-between">
-                      <h4 className="m-0">
-                        <Trans ns="video">Incident Video</Trans>
-                      </h4>
-                    </Card.Header>
-                    <Card.Body className="block">
-                      <VideoPlayer incidentID={incident.incident_id} mediaURL={videoURL} />
-                    </Card.Body>
-                  </Card>
-                </Col>
-              </Row>
-            )}
+            <VideoPlayerCard videoURLs={videoURLs} />
 
             <Row>
               <Col>


### PR DESCRIPTION
To use the `iframe` APIs for YouTube and Vimeo, I found the [`react-player`](https://www.npmjs.com/package/react-player) NPM package. This takes care of a lot of the logic (grabbing the video ID, platform, creating embed links, etc.), is integrated with a lot more video sources (good to look into this later) and uses the Video Player APIs for more sources.

I integrate the fallback image component into the VideoPlayer component and that's slightly different for each place it's used. For the Incident Video card in the main page, I created a recursive VideoPlayerCard component that tries the videos and if they're private, it goes to the next one, and if it runs out, it returns null. Did some preliminary testing with YouTube and Vimeo videos of my own.