### PR TITLE
refactor video checks

### DIFF
--- a/site/gatsby-site/src/components/cite/VideoPlayer.js
+++ b/site/gatsby-site/src/components/cite/VideoPlayer.js
@@ -1,61 +1,12 @@
 import React, { useState } from 'react';
 import ReactPlayer from 'react-player/lazy';
+import { isVideo } from 'utils/video';
 
 /*
   Example videos:
-
-  youtube       - https://youtu.be/cQ54GDm1eL0
-  vimeo         - https://vimeo.com/753626331
-  streamable    - https://streamable.com/4f031u
+   - youtube - https://youtu.be/cQ54GDm1eL0
+   - vimeo   - https://vimeo.com/753626331
 */
-
-export const youtubeRegex =
-  /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w]+\?v=|embed\/|v\/)?)([\w]+)(\S+)?$/;
-
-export const vimeoRegex = /^https?:\/\/(www.)?vimeo.com\/([a-zA-Z0-9_-]+)/;
-
-// const twitterRegex = /^https:\/\/(www.)?twitter.com\/\w+\/status\/([0-9]+)/;
-
-export const isVideo = (url) => {
-  if (youtubeRegex.test(url)) {
-    return 'youtube/' + url.match(youtubeRegex)[5];
-  }
-
-  if (vimeoRegex.test(url)) {
-    return 'vimeo/' + url.match(vimeoRegex)[2];
-  }
-
-  return false;
-};
-
-// grab the video_id type
-export const typeMedia = (url) => {
-  // return the youtube id.
-  if (youtubeRegex.test(url)) {
-    return 'youtube';
-  }
-
-  // return the vimeo id
-  if (vimeoRegex.test(url)) {
-    return 'vimeo';
-  }
-
-  return 'fall_back';
-};
-
-export const grabVideoID = (video_id, url) => {
-  // return the youtube id.
-
-  if (video_id == 'youtube') {
-    return url.match(youtubeRegex)[5];
-  }
-
-  // return the vimeo id
-  if (video_id == 'vimeo') {
-    return url.match(vimeoRegex)[2];
-  }
-  return 'fall_back';
-};
 
 const VideoPlayer = ({ mediaURL, className = '', fallback = null, onError = () => {} }) => {
   if (!isVideo(mediaURL)) {
@@ -73,7 +24,7 @@ const VideoPlayer = ({ mediaURL, className = '', fallback = null, onError = () =
     setUseVideo(false);
   }
 
-  const [useVideo, setUseVideo] = useState(isVideo(mediaURL));
+  const [useVideo, setUseVideo] = useState(true);
 
   return useVideo ? (
     <div className={`aspect-w-16 aspect-h-9 ${className}`}>

--- a/site/gatsby-site/src/components/forms/PreviewImageInputGroup.js
+++ b/site/gatsby-site/src/components/forms/PreviewImageInputGroup.js
@@ -4,6 +4,7 @@ import { Spinner } from 'flowbite-react';
 import { Trans } from 'react-i18next';
 import TextInputGroup from './TextInputGroup';
 import { Image } from 'utils/cloudinary';
+import { isVideo } from 'utils/video';
 import { isWebUri } from 'valid-url';
 
 const IMG_FALLBACK = 'fallback.jpg';
@@ -34,34 +35,10 @@ export default function PreviewImageInputGroup({
 
   const imageUrl = useRef(values.media_url);
 
-  const isVideo = (url) => {
-    const youtubeRegex =
-      /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w]+\?v=|embed\/|v\/)?)([\w]+)(\S+)?$/;
-
-    const vimeoRegex = /^https?:\/\/(www.)?vimeo.com\/([a-zA-Z0-9_-]+)/;
-    // const twitterRegex = /^https:\/\/(www.)?twitter.com\/\w+\/status\/([0-9]+)/;
-
-    if (youtubeRegex.test(url)) {
-      return 'youtube/' + url.match(youtubeRegex)[5];
-    }
-
-    if (vimeoRegex.test(url)) {
-      return 'vimeo/' + url.match(vimeoRegex)[2];
-    }
-
-    return false;
-  };
-
   const updateCloudinaryID = () => {
-    if (isWebUri(values.media_url)) {
-      const videoPublicID = isVideo(values.media_url);
-
-      if (videoPublicID) {
-        setImageReferenceError(false);
-        setCloudinaryID(values.media_url);
-      } else {
-        setCloudinaryID(IMG_FALLBACK);
-      }
+    if (isWebUri(values.media_url) && isVideo(values.media_url)) {
+      setImageReferenceError(false);
+      setCloudinaryID(values.media_url);
     } else {
       setCloudinaryID(IMG_FALLBACK);
     }

--- a/site/gatsby-site/src/components/forms/SubmitForm.js
+++ b/site/gatsby-site/src/components/forms/SubmitForm.js
@@ -28,7 +28,7 @@ import { Helmet } from 'react-helmet';
 import { Button } from 'flowbite-react';
 import { getCloudinaryPublicID } from 'utils/cloudinary';
 // validator from a new file
-import { checkLink } from './check_video';
+import { checkLink } from 'utils/video';
 
 const CustomDateParam = {
   encode: encodeDate,
@@ -176,14 +176,10 @@ const SubmitForm = () => {
 
       const isValid = await checkLink(values.media_url);
 
-      // check if the media url is valid. if not then it should return false.
-
-      // if the media url is not a valid youtube or vimeo video, the set the media url to an empty string.
-      if (isValid == false) {
+      // if the media url is not a valid youtube or vimeo video, set the media url to an empty string.
+      if (!isValid) {
         values.media_url = '';
       }
-
-      // grab the video id from a valid vimeo or youtube url
 
       const submission = {
         ...values,

--- a/site/gatsby-site/src/templates/citeTemplate.js
+++ b/site/gatsby-site/src/templates/citeTemplate.js
@@ -27,7 +27,7 @@ import { SUBSCRIPTION_TYPE } from 'utils/subscriptions';
 import VariantList from 'components/variants/VariantList';
 import { useQueryParams, StringParam, withDefault } from 'use-query-params';
 import Tools from 'components/cite/Tools';
-import { isVideo } from 'components/cite/VideoPlayer';
+import { isVideo } from 'utils/video';
 import VideoPlayerCard from 'components/cite/VideoPlayerCard';
 
 function CiteTemplate({

--- a/site/gatsby-site/src/utils/cloudinary.js
+++ b/site/gatsby-site/src/utils/cloudinary.js
@@ -5,6 +5,7 @@ import { defaultImage, format, quality } from '@cloudinary/base/actions/delivery
 import { auto } from '@cloudinary/base/qualifiers/format';
 import { auto as qAuto } from '@cloudinary/base/qualifiers/quality';
 import config from '../../config';
+import { videoCloudinaryID } from './video';
 
 const IMG_FALLBACK = 'fallback.jpg';
 
@@ -24,27 +25,7 @@ const Image = ({
   plugins = [lazyload()],
   style,
 }) => {
-  const toVideo = (url) => {
-    if (url.startsWith('reports/')) {
-      url = url.replace('reports/', '');
-    }
-    const youtubeRegex =
-      /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w]+\?v=|embed\/|v\/)?)([\w]+)(\S+)?$/;
-
-    const vimeoRegex = /^https?:\/\/(www.)?vimeo.com\/([a-zA-Z0-9_-]+)/;
-
-    if (youtubeRegex.test(url)) {
-      return 'youtube/' + url.match(youtubeRegex)[5];
-    }
-
-    if (vimeoRegex.test(url)) {
-      return 'vimeo/' + url.match(vimeoRegex)[2];
-    }
-
-    return url;
-  };
-
-  const [cloudinaryId, setCloudinaryID] = useState(toVideo(publicID));
+  const [cloudinaryId, setCloudinaryID] = useState(videoCloudinaryID(publicID));
   // const [tweetThumb, setTweetThumb] = useState('');
 
   const imageElement = useRef(null);

--- a/site/gatsby-site/src/utils/video.js
+++ b/site/gatsby-site/src/utils/video.js
@@ -1,5 +1,3 @@
-// import React from 'react';
-
 function checkYoutube(id) {
   // check if the video exist
   const img = new Image();
@@ -41,12 +39,32 @@ async function checkVimeo(id) {
   }
 }
 
+const youtubeRegex =
+  /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w]+\?v=|embed\/|v\/)?)([\w]+)(\S+)?$/;
+
+const vimeoRegex = /^https?:\/\/(www.)?vimeo.com\/([a-zA-Z0-9_-]+)/;
+
+export const videoCloudinaryID = (publicID) => {
+  if (publicID.startsWith('reports/')) {
+    publicID = publicID.replace('reports/', '');
+  }
+
+  if (youtubeRegex.test(publicID)) {
+    return 'youtube/' + publicID.match(youtubeRegex)[5];
+  }
+
+  if (vimeoRegex.test(publicID)) {
+    return 'vimeo/' + publicID.match(vimeoRegex)[2];
+  }
+
+  return publicID;
+};
+
+export const isVideo = (url) => {
+  return youtubeRegex.test(url) || vimeoRegex.test(url);
+};
+
 export async function checkLink(url) {
-  const vimeoRegex = /^https?:\/\/(www.)?vimeo.com\/([a-zA-Z0-9_-]+)/;
-
-  const youtubeRegex =
-    /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w]+\?v=|embed\/|v\/)?)([\w]+)(\S+)?$/;
-
   // check if the youtube url exist.
   if (youtubeRegex.test(url)) {
     return checkYoutube(url.match(youtubeRegex)[5]);


### PR DESCRIPTION
Responding to MOST (not all) of Pablo's comments on [this PR](https://github.com/responsible-ai-collaborative/aiid/pull/1979).

Moved all the video checks to `utils/video.js` to replace `check_video.js`. 

**Please test it well - especially the submit form - before approving.** I saw that the video player was working but didn't test the form.